### PR TITLE
Don't allow to configure after tests are running

### DIFF
--- a/index.js
+++ b/index.js
@@ -603,6 +603,11 @@ module.exports = test
 function configure ({ timeout = DEFAULT_TIMEOUT, bail = false, solo = false } = {}) {
   const runner = getRunner()
 
+  if (runner.tests.count > 0 || runner.assertions.count > 0) {
+    throw new Error('ERR_CONFIGURE_FIRST')
+    return
+  }
+
   runner.timeout = DEFAULT_TIMEOUT
   runner.bail = bail
   runner.explicitSolo = solo

--- a/index.js
+++ b/index.js
@@ -604,7 +604,7 @@ function configure ({ timeout = DEFAULT_TIMEOUT, bail = false, solo = false } = 
   const runner = getRunner()
 
   if (runner.tests.count > 0 || runner.assertions.count > 0) {
-    throw new Error('Configure before running any tests')
+    throw new Error('configuration must happen prior to registering any tests')
   }
 
   runner.timeout = DEFAULT_TIMEOUT

--- a/index.js
+++ b/index.js
@@ -604,8 +604,7 @@ function configure ({ timeout = DEFAULT_TIMEOUT, bail = false, solo = false } = 
   const runner = getRunner()
 
   if (runner.tests.count > 0 || runner.assertions.count > 0) {
-    throw new Error('ERR_CONFIGURE_FIRST')
-    return
+    throw new Error('Configure before running any tests')
   }
 
   runner.timeout = DEFAULT_TIMEOUT


### PR DESCRIPTION
The current counters are for already running tests or assertions, so they show zero even tho I already added a test. Should I add a counter of added tests so the behaviour for configure is the same as 2.4.0?

Also, not sure how to properly throw an error in this scenario for `configure` function.

```js
import brittle from '/self/brittle/index.js'
const { test, configure } = brittle

// it show zeros
console.log(test().runner.tests, test().runner.assertions)

test('a test', async ({ pass }) => {
  pass()
})

// still show zeros
console.log(test().runner.tests, test().runner.assertions)

// this will be ok (although, in 2.4.0 is not allowed)
configure({})

setTimeout(() => {
  // now it show ones
  console.log(test().runner.tests, test().runner.assertions)

  // and so this throws as it's not okay
  configure({})
}, 100)
```