### PR TITLE
(draft) Should not be able to add teardown after end

### DIFF
--- a/index.js
+++ b/index.js
@@ -409,7 +409,7 @@ class Test {
   }
 
   _teardown (fn, opts) {
-    if (this.isDone) throw new Error('Can\'t add teardown after end')
+    if (this.isEnded || this.isDone) throw new Error('Can\'t add teardown after end')
     this._teardowns.push([(opts && opts.order) || 0, fn])
   }
 

--- a/index.js
+++ b/index.js
@@ -409,6 +409,7 @@ class Test {
   }
 
   _teardown (fn, opts) {
+    if (this.isDone) throw new Error('Can\'t add teardown after end')
     this._teardowns.push([(opts && opts.order) || 0, fn])
   }
 


### PR DESCRIPTION
For some reason the `throw` inside `_teardown` is not throwing.

This PR is to cover this case:
```js
test('teardown after end', async function (t) {
  t.pass()
  await t.end()
  t.teardown(() => {})
})
```
As in the brittle stable this is not allowed.

Also, `this.isDone` vs `this.isEnded`?