### PR TITLE
Should not be able to comment after end

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ class Runner {
   }
 
   comment (...message) {
-    if (this.isEnded) throw new Error('Can\'t comment after end')
+    if (this.isEnded || this.isDone) throw new Error('Can\'t comment after end')
     this.log('#', ...message)
   }
 

--- a/index.js
+++ b/index.js
@@ -123,7 +123,6 @@ class Runner {
   }
 
   comment (...message) {
-    if (this.isEnded || this.isDone) throw new Error('Can\'t comment after end')
     this.log('#', ...message)
   }
 
@@ -292,6 +291,7 @@ class Test {
   }
 
   _comment (...m) {
+    if (this.isEnded || this.isDone) throw new Error('Can\'t comment after end')
     this.runner.log(INDENT + '#', ...m)
   }
 

--- a/index.js
+++ b/index.js
@@ -123,6 +123,7 @@ class Runner {
   }
 
   comment (...message) {
+    if (this.isEnded) throw new Error('Can\'t comment after end')
     this.log('#', ...message)
   }
 


### PR DESCRIPTION
I can't make work the error.

```js
test('comment after end', async (t) => {
  t.plan(1)
  t.is(1, 1)
  setImmediate(() => t.comment('test'))
})
```
In brittle stable is not allowed to comment after end.